### PR TITLE
fix: include or log stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,28 @@ Run Terraform Destroy
     ${rc}    ${output}    Terraform Destroy    ${PATH_TO_TERRAFORM_SCRIPT}
     Should Contain    ${output}    Destroy complete! Resources: 1 destroyed.
 ```
+
+---
+## Development
+
+Install `poetry` on your system with `pip install poetry`.
+
+Then setup the current project in a virtual env for development:
+
+```
+$ poetry env use $(which python3)
+$ source $(poetry env info --path)/bin/activate
+$ poetry install
+```
+
+Run the tests:
+
+```
+$ poetry run pytest -v
+```
+
+Exit the virtualenv
+
+```
+deactivate
+```


### PR DESCRIPTION
We found that when TF was failing, no stderr content was included in the Robot Framework test reports.

This PR pulls in the stderr content so that it is part of the output for `init`, `plan`, `apply` and `destroy` and is logged at INFO level for the `get terraform state` function.

